### PR TITLE
[ISS-250] Use source interface configured under radius server for sending access request

### DIFF
--- a/scripts/hostcfgd
+++ b/scripts/hostcfgd
@@ -678,9 +678,9 @@ class AaaCfg(object):
             "RADIUS_SERVER|{}: src_intf found. Ignoring src_ip".format(addr))
                     # RADIUS: If server.src_intf, then get the corresponding
                     # src_ip based on the server.ip, and set it.
-                    src_ip = self.get_interface_ip(server['src_intf'], addr)
-                    if len(src_ip) > 0:
-                        server['src_ip'] = src_ip
+                    rad_src_ip = self.get_interface_ip(server['src_intf'], addr)
+                    if len(rad_src_ip) > 0:
+                        server['src_ip'] = rad_src_ip
                     elif 'src_ip' in server:
                         syslog.syslog(syslog.LOG_INFO, \
             "RADIUS_SERVER|{}: src_intf has no usable IP addr.".format(addr))

--- a/scripts/hostcfgd
+++ b/scripts/hostcfgd
@@ -342,7 +342,8 @@ class Iptables(object):
 
 
 class AaaCfg(object):
-    def __init__(self):
+    def __init__(self, CfgDb):
+        self.config_db = CfgDb
         self.authentication_default = {
             'login': 'local',
         }
@@ -439,7 +440,7 @@ class AaaCfg(object):
             if new_ipv4_addr != "" and new_ipv6_addr != "":
                 break
             ip_str = it[1].split("/")[0]
-            ip_addr = ipaddress.IPAddress(ip_str)
+            ip_addr = ipaddress.ip_address(ip_str)
             # Pick the first IP address from the table that matches the source interface
             if isinstance(ip_addr, ipaddress.IPv6Address):
                 if new_ipv6_addr != "":
@@ -2076,7 +2077,7 @@ class HostConfigDaemon:
         self.is_multi_npu = device_info.is_multi_npu()
 
         # Initialize AAACfg
-        self.aaacfg = AaaCfg()
+        self.aaacfg = AaaCfg(self.config_db)
 
         # Initialize PasswHardening
         self.passwcfg = PasswHardening()

--- a/tests/common/mock_configdb.py
+++ b/tests/common/mock_configdb.py
@@ -38,6 +38,10 @@ class MockConfigDb(object):
     def get(self, db_id, key, field):
         return MockConfigDb.CONFIG_DB[key][field]
 
+    def get_keys(self, pattern):
+        return [(key.split("|")[0], key.split("|")[1]) \
+                for key in MockConfigDb.CONFIG_DB[pattern]]
+
     def get_entry(self, key, field):
         return MockConfigDb.CONFIG_DB[key][field]
 

--- a/tests/hostcfgd/hostcfgd_radius_test.py
+++ b/tests/hostcfgd/hostcfgd_radius_test.py
@@ -39,7 +39,7 @@ class TestHostcfgdRADIUS(TestCase):
         Test hostcfd daemon - RADIUS
     """
     def run_diff(self, file1, file2):
-        _, output = getstatusoutput_noshell(['diff', '-uR', file1, file2])
+        _, output = getstatusoutput_noshell(['diff', '-ur', file1, file2])
         return output
 
 

--- a/tests/hostcfgd/sample_output/RADIUS/10.10.10.3_1645.conf
+++ b/tests/hostcfgd/sample_output/RADIUS/10.10.10.3_1645.conf
@@ -1,0 +1,2 @@
+# server[:port]      shared_secret    timeout(s)    source_ip     vrf
+[10.10.10.3]:1645  pass3  3   10.10.11.10   

--- a/tests/hostcfgd/sample_output/RADIUS/10.10.10.4_1645.conf
+++ b/tests/hostcfgd/sample_output/RADIUS/10.10.10.4_1645.conf
@@ -1,0 +1,2 @@
+# server[:port]      shared_secret    timeout(s)    source_ip     vrf
+[10.10.10.4]:1645  pass4  4   1.1.1.15   

--- a/tests/hostcfgd/sample_output/RADIUS/common-auth-sonic
+++ b/tests/hostcfgd/sample_output/RADIUS/common-auth-sonic
@@ -10,10 +10,12 @@
 # here are the per-package modules (the "Primary" block)
 
 # root user can only be authenticated locally. Jump to local.
-auth	[success=2 default=ignore]	pam_succeed_if.so user = root
+auth	[success=4 default=ignore]	pam_succeed_if.so user = root
 # For the RADIUS servers, on success jump to the cache the MPL(Privilege)
-auth	[success=3 new_authtok_reqd=done default=ignore auth_err=die]	pam_radius_auth.so conf=/etc/pam_radius_auth.d/10.10.10.1_1645.conf privilege_level protocol=pap retry=1 nas_ip_address=10.10.10.10 debug try_first_pass
-auth	[success=2 new_authtok_reqd=done default=ignore auth_err=die]	pam_radius_auth.so conf=/etc/pam_radius_auth.d/10.10.10.2_1645.conf privilege_level protocol=chap retry=2 nas_ip_address=10.10.10.10 debug try_first_pass
+auth	[success=5 new_authtok_reqd=done default=ignore auth_err=die]	pam_radius_auth.so conf=/etc/pam_radius_auth.d/10.10.10.1_1645.conf privilege_level protocol=pap retry=1 nas_ip_address=10.10.10.10 debug try_first_pass
+auth	[success=4 new_authtok_reqd=done default=ignore auth_err=die]	pam_radius_auth.so conf=/etc/pam_radius_auth.d/10.10.10.2_1645.conf privilege_level protocol=chap retry=2 nas_ip_address=10.10.10.10 debug try_first_pass
+auth	[success=3 new_authtok_reqd=done default=ignore auth_err=die]	pam_radius_auth.so conf=/etc/pam_radius_auth.d/10.10.10.3_1645.conf privilege_level protocol=chap retry=3 nas_ip_address=10.10.10.10 debug try_first_pass
+auth	[success=2 new_authtok_reqd=done default=ignore auth_err=die]	pam_radius_auth.so conf=/etc/pam_radius_auth.d/10.10.10.4_1645.conf privilege_level protocol=pap retry=4 nas_ip_address=10.10.10.10 debug try_first_pass
 # Local
 auth	[success=done new_authtok_reqd=done default=ignore auth_err=die maxtries=die]	pam_unix.so nullok try_first_pass
 auth	requisite	pam_deny.so

--- a/tests/hostcfgd/test_radius_vectors.py
+++ b/tests/hostcfgd/test_radius_vectors.py
@@ -8,6 +8,17 @@ HOSTCFGD_TEST_RADIUS_VECTOR = [
         "RADIUS",
         {
             "config_db": {
+               "MGMT_INTERFACE": {
+                    "eth0|1.1.1.15/23": {
+                        "gwaddr": "1.1.1.10"
+                    },
+                    "eth0|2404::2/64": {
+                        "gwaddr": "2404::1"
+                    }
+                },
+                "PORTCHANNEL_INTERFACE": {
+                    "PortChannel0001|10.10.11.10/32": {}
+                 },
                 "DEVICE_METADATA": {
                     "localhost": {
                         "hostname": "radius",
@@ -59,6 +70,20 @@ HOSTCFGD_TEST_RADIUS_VECTOR = [
                         "retransmit": "2",
                         "timeout": "2",
                         "passkey": "pass2",
+                    },
+                    "10.10.10.3": {
+                        "auth_type": "chap",
+                        "retransmit": "3",
+                        "timeout": "3",
+                        "passkey": "pass3",
+                        "src_intf": "PortChannel0001",
+                    },
+                    "10.10.10.4": {
+                        "auth_type": "pap",
+                        "retransmit": "4",
+                        "timeout": "4",
+                        "passkey": "pass4",
+                        "src_intf": "eth0",
                     }
                 },
             },
@@ -107,6 +132,20 @@ HOSTCFGD_TEST_RADIUS_VECTOR = [
                         "retransmit": "2",
                         "timeout": "2",
                         "passkey": "pass2",
+                    },
+                    "10.10.10.3": {
+                        "auth_type": "chap",
+                        "retransmit": "3",
+                        "timeout": "3",
+                        "passkey": "pass3",
+                        "src_intf": "PortChannel0001",
+                    },
+                    "10.10.10.4": {
+                        "auth_type": "pap",
+                        "retransmit": "4",
+                        "timeout": "4",
+                        "passkey": "pass4",
+                        "src_intf": "eth0",
                     }
                 },
             },


### PR DESCRIPTION
Why I did it
When authentication is triggered by the DUT, source interface configured under radius needs to be used for sending access request.

How I did it
config db needs to be looked up for the source interface from the radius config and store the IP address of this interface in the pam_radius_auth file.

How to verify:
- Configured AAA authentication, configured radius with source interface as uplink port channel.
 _tb1@sonic:~$ sudo config aaa authentication login radius local_
 _tb1@sonic:~$ sudo config radius add -s PortChannel100 -k test -p 3 10.120.20.1_
- initiate ssh into the dut. this triggers radius auth request
- access request is sent out with port channel ip address as source